### PR TITLE
Refactor vendor and clean up CSS styling

### DIFF
--- a/src/app/dashboard-vendor-mapping-modal/dashboard-vendor-mapping-modal.component.html
+++ b/src/app/dashboard-vendor-mapping-modal/dashboard-vendor-mapping-modal.component.html
@@ -15,7 +15,7 @@
   </button>
 </mat-dialog-actions>
 
-<h2 mat-dialog-title>{{ data?.mapping ? 'Edit Vendor Logo Mapping' : 'Add Vendor Logo Mapping' }}</h2>
+<h2 mat-dialog-title>{{ data?.mapping ? 'Edit Vendor' : 'Add Vendor' }}</h2>
 
 <mat-dialog-content class="dialog-fields">
   <mat-form-field class="watch-field">
@@ -46,5 +46,7 @@
       <img [src]="logoUrl" alt="Logo preview">
     </div>
   </div>
+
+  <mat-slide-toggle [(ngModel)]="watched">Watch this vendor</mat-slide-toggle>
 
 </mat-dialog-content>

--- a/src/app/dashboard-vendor-mapping-modal/dashboard-vendor-mapping-modal.component.scss
+++ b/src/app/dashboard-vendor-mapping-modal/dashboard-vendor-mapping-modal.component.scss
@@ -17,7 +17,7 @@
 .dialog-fields {
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: 20px;
 }
 
 .logo-section {

--- a/src/app/dashboard-vendor-mapping-modal/dashboard-vendor-mapping-modal.component.ts
+++ b/src/app/dashboard-vendor-mapping-modal/dashboard-vendor-mapping-modal.component.ts
@@ -8,13 +8,15 @@ import { ConfirmModalButtons, ConfirmModalConfig } from '../core/dataTypes';
 import { ConfirmModalComponent } from '../confirm-modal/confirm-modal.component';
 
 export type DashboardVendorMappingModalResult =
-  | { action: 'save'; mapping: IVendorLogoRule }
-  | { action: 'delete' }
+  | { action: 'save'; mapping: IVendorLogoRule; watched: boolean }
+  | { action: 'delete'; watched: boolean }
   | { action: 'close' };
 
 export interface IDashboardVendorMappingModalData {
   mapping?: IVendorLogoRule;
   index?: number;
+  watched?: boolean;
+  initialVendorName?: string;
 }
 
 @Component({
@@ -29,6 +31,7 @@ export class DashboardVendorMappingModalComponent {
   pattern = '';
   vendorName = '';
   logoUrl = '';
+  watched = false;
   readonly regexErrorStateMatcher: ErrorStateMatcher = {
     isErrorState: (_control: FormControl | null, _form: FormGroupDirective | NgForm | null): boolean => this.showPatternError
   };
@@ -41,7 +44,10 @@ export class DashboardVendorMappingModalComponent {
       this.pattern = this.data.mapping.pattern || '';
       this.vendorName = this.data.mapping.vendorName || '';
       this.logoUrl = this.data.mapping.logoUrl || '';
+    } else if (this.data?.initialVendorName) {
+      this.vendorName = this.data.initialVendorName || '';
     }
+    this.watched = !!this.data?.watched;
   }
 
   close() {
@@ -86,10 +92,11 @@ export class DashboardVendorMappingModalComponent {
     this.dialogRef.close({
       action: 'save',
       mapping: {
-      pattern: this.pattern.trim(),
-      vendorName: this.vendorName.trim(),
-      logoUrl: this.logoUrl.trim()
-      }
+        pattern: this.pattern.trim(),
+        vendorName: this.vendorName.trim(),
+        logoUrl: this.logoUrl.trim()
+      },
+      watched: this.watched
     } as DashboardVendorMappingModalResult);
   }
 
@@ -118,7 +125,7 @@ export class DashboardVendorMappingModalComponent {
     const dialogRef = this.dialog.open(ConfirmModalComponent, dialogConfig);
     dialogRef.afterClosed().subscribe((confirmed: boolean) => {
       if (!confirmed) { return; }
-      this.dialogRef.close({ action: 'delete' } as DashboardVendorMappingModalResult);
+      this.dialogRef.close({ action: 'delete', watched: this.watched } as DashboardVendorMappingModalResult);
     });
   }
 }

--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -231,6 +231,7 @@
           <div
             *ngFor="let item of getVendorGridItems(); trackBy: trackByVendorGridItem"
             class="vendor-mapping-grid-item"
+            [class.vendor-mapping-grid-item-watched]="item.isWatched"
             role="button"
             tabindex="0"
             [matMenuTriggerFor]="vendorCardActionsMenu"

--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -195,147 +195,75 @@
     </mat-card>
 
     <mat-card>
-      <mat-card-title>Vendors</mat-card-title>
+      <mat-card-title>
+        <span class="card-title-row">
+          <span>Vendors</span>
+          <button mat-icon-button matTooltip="Add vendor" (click)="openAddVendorMappingModal()">
+            <mat-icon>add</mat-icon>
+          </button>
+        </span>
+      </mat-card-title>
       <mat-card-content>
-        <div class="section-title">
-          Watched Vendors
-          <button mat-icon-button matTooltip="Add watched vendor" (click)="openAddWatchedVendorModal()">
-            <mat-icon>add</mat-icon>
-          </button>
-        </div>
-        <mat-list dense>
-          <mat-list-item *ngFor="let item of viewModel.watchedVendorsResolved; trackBy: trackByWatchedVendorResolved">
-            <div
-              class="row row-clickable vendor-row"
-              role="button"
-              tabindex="0"
-              [matMenuTriggerFor]="watchedVendorActionsMenu"
-              [attr.aria-label]="'Actions for ' + item.displayName">
-              <span class="vendor-title">
-                <img *ngIf="item.logoUrl" class="vendor-logo" [src]="item.logoUrl" alt="" aria-hidden="true">
-                <span>
-                  <span class="vendor-name">{{item.displayName}}</span>
-                  <span class="metric-chip amount-inline">{{item.spent | currency}}</span>
-                </span>
-              </span>
-              <span class="row-actions">
-                <mat-menu #watchedVendorActionsMenu="matMenu">
-                  <button mat-menu-item [routerLink]="['/transactions']" [queryParams]="getTransactionQueryParamsForVendor(item.displayName)">
-                    <mat-icon>view_list</mat-icon>
-                    <span>Open transactions</span>
-                  </button>
-                  <button mat-menu-item (click)="removeWatchedVendorByName(item.displayName)">
-                    <mat-icon>close</mat-icon>
-                    <span>Remove watched vendor</span>
-                  </button>
-                </mat-menu>
-                <span class="row-chevron" aria-hidden="true">
-                  <mat-icon>chevron_right</mat-icon>
-                </span>
-              </span>
-            </div>
-          </mat-list-item>
-
-          <mat-list-item *ngFor="let item of viewModel.watchedVendorsMissing; trackBy: trackByWatchedVendorMissing">
-            <div
-              class="row row-clickable vendor-row"
-              role="button"
-              tabindex="0"
-              [matMenuTriggerFor]="watchedVendorMissingActionsMenu"
-              [attr.aria-label]="'Actions for ' + item.displayName">
-              <span>{{item.displayName}} <span class="muted">(not in this month)</span></span>
-              <span class="row-actions">
-                <mat-menu #watchedVendorMissingActionsMenu="matMenu">
-                  <button mat-menu-item disabled>
-                    <mat-icon>view_list</mat-icon>
-                    <span>Open transactions</span>
-                  </button>
-                  <button mat-menu-item (click)="removeWatchedVendorMissing(item.key)">
-                    <mat-icon>close</mat-icon>
-                    <span>Remove watched vendor</span>
-                  </button>
-                </mat-menu>
-                <span class="row-chevron" aria-hidden="true">
-                  <mat-icon>chevron_right</mat-icon>
-                </span>
-              </span>
-            </div>
-          </mat-list-item>
-
-          <mat-list-item *ngIf="viewModel.watchedVendorsResolved.length === 0 && viewModel.watchedVendorsMissing.length === 0">
-            <div class="muted">No watched vendors yet.</div>
-          </mat-list-item>
-        </mat-list>
-
-        <div class="section-title">Top Spending Vendors</div>
-        <mat-list dense>
-          <mat-list-item *ngFor="let item of viewModel.topSpendingVendors; trackBy: trackByTopVendor">
-            <div
-              class="row row-clickable vendor-row"
-              role="button"
-              tabindex="0"
-              [matMenuTriggerFor]="topVendorActionsMenu"
-              [attr.aria-label]="'Actions for ' + item.vendorName">
-              <span class="vendor-title">
-                <img *ngIf="item.logoUrl" class="vendor-logo" [src]="item.logoUrl" alt="{{item.vendorName}} logo">
-                <span>
-                  <span class="vendor-name">{{item.vendorName}}</span>
-                  <span class="metric-chip amount-inline">{{-item.spent | currency}}</span>
-                </span>
-              </span>
-              <span class="row-actions">
-                <mat-menu #topVendorActionsMenu="matMenu">
-                  <button mat-menu-item [routerLink]="['/transactions']" [queryParams]="getTransactionQueryParamsForVendor(item.vendorName)">
-                    <mat-icon>view_list</mat-icon>
-                    <span>Open transactions</span>
-                  </button>
-                </mat-menu>
-                <span class="row-chevron" aria-hidden="true">
-                  <mat-icon>chevron_right</mat-icon>
-                </span>
-              </span>
-            </div>
-          </mat-list-item>
-          <mat-list-item *ngIf="viewModel.topSpendingVendors.length === 0">
-            <div class="muted">No vendor spend yet.</div>
-          </mat-list-item>
-        </mat-list>
-
-        <div class="section-title">
-          Vendor Mappings
-          <button mat-icon-button matTooltip="Add vendor mapping" (click)="openAddVendorMappingModal()">
-            <mat-icon>add</mat-icon>
-          </button>
-        </div>
-
         <div class="vendor-mapping-toolbar">
           <mat-form-field class="vendor-mapping-filter" appearance="outline">
-            <mat-label>Filter mappings</mat-label>
+            <mat-label>Filter vendors</mat-label>
             <input
               matInput
-              [value]="vendorMappingFilter"
-              (input)="onVendorMappingFilterChange($any($event.target).value)"
+              [value]="vendorSearch"
+              (input)="onVendorSearchChange($any($event.target).value)"
               placeholder="Search vendor name">
-            <button *ngIf="vendorMappingFilter" matSuffix mat-icon-button aria-label="Clear filter" (click)="onVendorMappingFilterChange('')">
+            <button *ngIf="vendorSearch" matSuffix mat-icon-button aria-label="Clear filter" (click)="onVendorSearchChange('')">
               <mat-icon>close</mat-icon>
             </button>
           </mat-form-field>
+
+          <mat-button-toggle-group
+            [value]="vendorSortMode"
+            aria-label="Sort vendors"
+            class="vendor-sort-toggle"
+            (change)="setVendorSortMode($event.value)">
+            <mat-button-toggle value="spend">Spend</mat-button-toggle>
+            <mat-button-toggle value="name">Name</mat-button-toggle>
+          </mat-button-toggle-group>
         </div>
 
         <div class="vendor-mapping-grid">
           <div
-            *ngFor="let item of getVendorMappingDisplayItems(); trackBy: trackByVendorMappingDisplayItem"
-            class="vendor-mapping-grid-item row-clickable"
+            *ngFor="let item of getVendorGridItems(); trackBy: trackByVendorGridItem"
+            class="vendor-mapping-grid-item"
             role="button"
             tabindex="0"
-            (click)="openEditVendorMappingModal(item.mapping, item.sourceIndex)"
-            [attr.aria-label]="'Edit mapping for ' + item.mapping.vendorName">
-            <img *ngIf="item.mapping.logoUrl" class="vendor-logo" [src]="item.mapping.logoUrl">
-            <span class="vendor-mapping-name">{{ item.mapping.vendorName }}</span>
+            [matMenuTriggerFor]="vendorCardActionsMenu"
+            [matMenuTriggerData]="{ item: item }"
+            [attr.aria-label]="'Actions for ' + item.displayName">
+            <span class="vendor-card-main">
+              <div  class="vendor-card-row">
+                <img *ngIf="item.logoUrl" class="vendor-logo" [src]="item.logoUrl" [alt]="item.displayName + ' logo'">
+                <mat-icon *ngIf="item.usesFallbackIcon" class="vendor-fallback-icon" aria-hidden="true">storefront</mat-icon>
+                <span class="vendor-mapping-name">{{ item.displayName }}</span>
+              </div>
+              <span class="metric-chip vendor-mapping-spend">{{-item.spent | currency}}</span>
+            </span>
+            <mat-icon *ngIf="item.isWatched" class="vendor-watch-icon" aria-hidden="true">visibility</mat-icon>
           </div>
         </div>
-        <div class="muted" *ngIf="getVendorMappingDisplayItems().length === 0">
-          <span>No vendor mappings yet.</span>
+        <mat-menu #vendorCardActionsMenu="matMenu">
+          <ng-template matMenuContent let-item="item">
+            <button mat-menu-item (click)="openVendorCardEdit(item)">
+              <mat-icon>edit</mat-icon>
+              <span>Edit Mapping</span>
+            </button>
+            <button mat-menu-item [routerLink]="['/transactions']" [queryParams]="getTransactionQueryParamsForVendor(item.displayName)">
+              <mat-icon>view_list</mat-icon>
+              <span>Open transactions</span>
+            </button>
+          </ng-template>
+        </mat-menu>
+        <div class="muted" *ngIf="viewModel.vendorCards.length === 0">
+          <span>No vendor spend yet.</span>
+        </div>
+        <div class="muted" *ngIf="viewModel.vendorCards.length > 0 && getVendorGridItems().length === 0">
+          <span>No vendors match that search.</span>
         </div>
       </mat-card-content>
     </mat-card>

--- a/src/app/dashboard/dashboard.component.scss
+++ b/src/app/dashboard/dashboard.component.scss
@@ -97,6 +97,13 @@
   margin: 8px 0;
 }
 
+.card-title-row {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+}
+
 .row {
   align-items: center;
   display: flex;
@@ -133,20 +140,25 @@
 }
 
 .vendor-mapping-toolbar {
-  align-items: flex-start;
+  align-items: center;
   display: flex;
+  flex-wrap: wrap;
   gap: 8px;
+  margin-bottom: 8px;
 }
 
 .vendor-mapping-filter {
   flex: 1;
   margin-bottom: 8px;
+  min-width: 220px;
 }
 
 .vendor-mapping-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, 115px);
-  gap: 24px;
+  grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
+  gap: 10px;
+  max-height: 300px;
+  overflow-y: auto;
 }
 
 .vendor-mapping-grid-item {
@@ -155,32 +167,62 @@
   border: 1px solid rgba(60, 64, 67, 0.2);
   border-radius: 10px;
   display: flex;
-  justify-content: flex-start;
-  gap: 8px;
-  min-height: 40px;
-  max-height: 40px;
-  width: 115px;
-  padding: 8px 10px;
+  min-height: 64px;
+  justify-content: space-between;
+  padding: 10px 12px;
 }
 
 .vendor-mapping-name {
-  display: block;
+  display: inline-flex;
   font-size: 0.92rem;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.vendor-mapping-grid-item .vendor-logo {
-  width: 22px;
-  height: 22px;
+.vendor-mapping-spend {
+  margin: 0 0 0 8px;
+  padding: 3px 10px;
 }
 
 .vendor-logo {
-  width: 18px;
-  height: 18px;
+  height: 24px;
+  width: 24px;
   min-width: 18px;
   object-fit: contain;
+}
+
+.vendor-card-row {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.vendor-card-main {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+}
+
+.vendor-fallback-icon {
+  color: #5f6368;
+  font-size: 22px;
+  height: 22px;
+  min-width: 22px;
+  width: 22px;
+}
+
+.vendor-watch-icon {
+  color: #188038;
+  font-size: 22px;
+  height: 22px;
+  width: 22px;
+  align-self: end;
+  font-variation-settings: 'FILL' 1;
 }
 
 .row-clickable {
@@ -223,6 +265,12 @@
 
 .amount-inline {
   margin-left: 8px;
+}
+
+@media (max-width: 599px) {
+  .vendor-mapping-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 .projection {

--- a/src/app/dashboard/dashboard.component.scss
+++ b/src/app/dashboard/dashboard.component.scss
@@ -173,15 +173,15 @@
 }
 
 .vendor-mapping-name {
-  display: inline-flex;
+  display: block;
   font-size: 0.92rem;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .vendor-mapping-spend {
-  margin: 0 0 0 8px;
   padding: 3px 10px;
 }
 
@@ -197,6 +197,7 @@
   display: flex;
   gap: 8px;
   justify-content: space-between;
+  min-width: 0;
   width: 100%;
 }
 

--- a/src/app/dashboard/dashboard.component.scss
+++ b/src/app/dashboard/dashboard.component.scss
@@ -143,14 +143,17 @@
   align-items: center;
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: 18px;
   margin-bottom: 8px;
 }
 
 .vendor-mapping-filter {
   flex: 1;
-  margin-bottom: 8px;
-  min-width: 220px;
+  min-width: 200px;
+}
+
+.vendor-sort-toggle {
+  border-radius: 25px;
 }
 
 .vendor-mapping-grid {
@@ -159,6 +162,7 @@
   gap: 10px;
   max-height: 300px;
   overflow-y: auto;
+  padding: 6px;
 }
 
 .vendor-mapping-grid-item {
@@ -170,6 +174,10 @@
   min-height: 64px;
   justify-content: space-between;
   padding: 10px 12px;
+}
+
+.vendor-mapping-grid-item-watched {
+  border: 1px solid #1a8039bd;
 }
 
 .vendor-mapping-name {

--- a/src/app/dashboard/dashboard.component.spec.ts
+++ b/src/app/dashboard/dashboard.component.spec.ts
@@ -50,7 +50,7 @@ describe('buildDashboardViewModel', () => {
     expect(normalizeCategoryKey('  Groceries  ')).toBe('groceries');
   });
 
-  it('excludes watched vendors with zero spend and keeps top vendors sorted and capped', () => {
+  it('returns all vendors with positive spend sorted by spend descending', () => {
     const vm = buildDashboardViewModel(
       [{ id: '1', name: 'Shopping', keywords: [], budgeted: 500, spent: 0, notes: '' }],
       [
@@ -76,10 +76,29 @@ describe('buildDashboardViewModel', () => {
       ]
     );
 
-    expect(vm.topSpendingVendors.length).toBe(5);
-    expect(vm.topSpendingVendors.map(v => v.vendorName)).toEqual(['A', 'B', 'C', 'D', 'E']);
-    expect(vm.topSpendingVendors.find(v => v.vendorName === 'F')).toBeUndefined();
-    expect(vm.topSpendingVendors.find(v => v.vendorName === 'Z')).toBeUndefined();
+    expect(vm.vendorCards.length).toBe(6);
+    expect(vm.vendorCards.map(v => v.vendorName)).toEqual(['A', 'B', 'C', 'D', 'E', 'F']);
+    expect(vm.vendorCards.find(v => v.vendorName === 'Z')).toBeUndefined();
+  });
+
+  it('keeps watched vendors visible without spend and without mappings', () => {
+    const vm = buildDashboardViewModel(
+      [{ id: '1', name: 'Shopping', keywords: [], budgeted: 500, spent: 0, notes: '' }],
+      [
+        { id: 't1', date: '01/10/2026', amount: -110, description: 'Amazon', category: 'Shopping', notes: '', status: 'Posted' }
+      ] as any,
+      '01/2026',
+      [],
+      ['amazon', 'ghost vendor'],
+      [
+        { pattern: '^Amazon$', vendorName: 'Amazon', logoUrl: 'a.png' }
+      ]
+    );
+
+    expect(vm.vendorCards).toEqual([
+      jasmine.objectContaining({ vendorName: 'Amazon', isWatched: true, hasSpend: true, spent: 110, usesFallbackIcon: false }),
+      jasmine.objectContaining({ vendorName: 'Ghost Vendor', isWatched: true, hasSpend: false, spent: 0, usesFallbackIcon: true, sourceIndex: -1 })
+    ]);
   });
 });
 
@@ -87,5 +106,137 @@ describe('DashboardComponent query params', () => {
   it('routes vendor drill-down using vendor query param', () => {
     const result = (DashboardComponent.prototype as any).getTransactionQueryParamsForVendor('Walmart');
     expect(result).toEqual({ vendor: 'Walmart' });
+  });
+});
+
+describe('DashboardComponent vendor grid', () => {
+  function createComponent(dialogOverrides: any = {}): DashboardComponent {
+    return new DashboardComponent(
+      {} as any,
+      { open: jasmine.createSpy('open'), ...dialogOverrides } as any,
+      {} as any,
+      { markForCheck: () => undefined } as any
+    );
+  }
+
+  it('filters vendor grid items by vendor name', () => {
+    const component = createComponent();
+    component.viewModel = {
+      vendorCards: [
+        { vendorName: 'Amazon', displayName: 'Amazon', logoUrl: 'a.png', spent: 30, isWatched: false, hasSpend: true, sourceIndex: 0, usesFallbackIcon: false },
+        { vendorName: 'Target', displayName: 'Target', logoUrl: 't.png', spent: 20, isWatched: false, hasSpend: true, sourceIndex: 1, usesFallbackIcon: false }
+      ]
+    } as any;
+
+    component.onVendorSearchChange('tar');
+
+    expect(component.getVendorGridItems().map(item => item.vendorName)).toEqual(['Target']);
+  });
+
+  it('sorts vendor grid items by name', () => {
+    const component = createComponent();
+    component.viewModel = {
+      vendorCards: [
+        { vendorName: 'Target', displayName: 'Target', logoUrl: 't.png', spent: 20, isWatched: false, hasSpend: true, sourceIndex: 0, usesFallbackIcon: false },
+        { vendorName: 'Amazon', displayName: 'Amazon', logoUrl: 'a.png', spent: 30, isWatched: false, hasSpend: true, sourceIndex: 1, usesFallbackIcon: false }
+      ]
+    } as any;
+
+    component.setVendorSortMode('name');
+
+    expect(component.getVendorGridItems().map(item => item.vendorName)).toEqual(['Amazon', 'Target']);
+  });
+
+  it('pins watched vendors above other vendors while sorting by spend', () => {
+    const component = createComponent();
+    component.viewModel = {
+      vendorCards: [
+        { vendorName: 'Target', displayName: 'Target', logoUrl: 't.png', spent: 20, isWatched: false, hasSpend: true, sourceIndex: 0, usesFallbackIcon: false },
+        { vendorName: 'Amazon', displayName: 'Amazon', logoUrl: 'a.png', spent: 30, isWatched: true, hasSpend: true, sourceIndex: 1, usesFallbackIcon: false },
+        { vendorName: 'Whole Foods', displayName: 'Whole Foods', logoUrl: '', spent: 0, isWatched: true, hasSpend: false, sourceIndex: -1, usesFallbackIcon: true }
+      ]
+    } as any;
+
+    expect(component.getVendorGridItems().map(item => item.vendorName)).toEqual(['Amazon', 'Whole Foods', 'Target']);
+  });
+
+  it('applies name sort within watched and non-watched blocks', () => {
+    const component = createComponent();
+    component.viewModel = {
+      vendorCards: [
+        { vendorName: 'Target', displayName: 'Target', logoUrl: 't.png', spent: 10, isWatched: false, hasSpend: true, sourceIndex: 0, usesFallbackIcon: false },
+        { vendorName: 'Whole Foods', displayName: 'Whole Foods', logoUrl: 'w.png', spent: 40, isWatched: true, hasSpend: true, sourceIndex: 1, usesFallbackIcon: false },
+        { vendorName: 'Amazon', displayName: 'Amazon', logoUrl: 'a.png', spent: 0, isWatched: true, hasSpend: false, sourceIndex: -1, usesFallbackIcon: false },
+        { vendorName: 'Best Buy', displayName: 'Best Buy', logoUrl: 'b.png', spent: 30, isWatched: false, hasSpend: true, sourceIndex: 2, usesFallbackIcon: false }
+      ]
+    } as any;
+
+    component.setVendorSortMode('name');
+
+    expect(component.getVendorGridItems().map(item => item.vendorName)).toEqual(['Amazon', 'Whole Foods', 'Best Buy', 'Target']);
+  });
+
+  it('keeps watched-first grouping when filtering search results', () => {
+    const component = createComponent();
+    component.viewModel = {
+      vendorCards: [
+        { vendorName: 'Costco', displayName: 'Costco', logoUrl: 'c.png', spent: 20, isWatched: false, hasSpend: true, sourceIndex: 0, usesFallbackIcon: false },
+        { vendorName: 'Corner Store', displayName: 'Corner Store', logoUrl: '', spent: 0, isWatched: true, hasSpend: false, sourceIndex: -1, usesFallbackIcon: true },
+        { vendorName: 'Coffee Shop', displayName: 'Coffee Shop', logoUrl: 'co.png', spent: 15, isWatched: false, hasSpend: true, sourceIndex: 1, usesFallbackIcon: false }
+      ]
+    } as any;
+
+    component.onVendorSearchChange('co');
+
+    expect(component.getVendorGridItems().map(item => item.vendorName)).toEqual(['Corner Store', 'Costco', 'Coffee Shop']);
+  });
+
+  it('routes mapped vendor edit through the existing edit modal flow', () => {
+    const component = createComponent();
+    component.viewModel = {
+      vendorMappings: [
+        { pattern: '^Amazon$', vendorName: 'Amazon', logoUrl: 'a.png' }
+      ]
+    } as any;
+    spyOn(component, 'openEditVendorMappingModal');
+
+    component.openVendorCardEdit({
+      vendorName: 'Amazon',
+      displayName: 'Amazon',
+      logoUrl: 'a.png',
+      spent: 30,
+      isWatched: false,
+      hasSpend: true,
+      sourceIndex: 0,
+      usesFallbackIcon: false
+    });
+
+    expect(component.openEditVendorMappingModal).toHaveBeenCalledWith(component.viewModel.vendorMappings[0], 0);
+  });
+
+  it('routes unmapped watched vendor edit through the add-prefilled modal flow', () => {
+    const afterClosed = jasmine.createSpy('afterClosed').and.returnValue({ subscribe: () => undefined });
+    const component = createComponent({
+      open: jasmine.createSpy('open').and.returnValue({ afterClosed })
+    });
+
+    component.openVendorCardEdit({
+      vendorName: 'Ghost Vendor',
+      displayName: 'Ghost Vendor',
+      logoUrl: '',
+      spent: 0,
+      isWatched: true,
+      hasSpend: false,
+      sourceIndex: -1,
+      usesFallbackIcon: true
+    });
+
+    expect(component.dialog.open).toHaveBeenCalled();
+    expect((component.dialog.open as jasmine.Spy).calls.mostRecent().args[1].data).toEqual(
+      jasmine.objectContaining({
+        initialVendorName: 'Ghost Vendor',
+        watched: true
+      })
+    );
   });
 });

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -6,7 +6,6 @@ import { getVendorMatch, IVendorLogoRule, parseMoney } from '../core/utilities';
 import { SharedModule } from '../shared/shared.module';
 import { MatDialog } from '@angular/material/dialog';
 import { DashboardWatchCategoryModalComponent } from '../dashboard-watch-category-modal/dashboard-watch-category-modal.component';
-import { DashboardWatchVendorModalComponent } from '../dashboard-watch-vendor-modal/dashboard-watch-vendor-modal.component';
 import { DashboardVendorMappingModalComponent, DashboardVendorMappingModalResult } from '../dashboard-vendor-mapping-modal/dashboard-vendor-mapping-modal.component';
 
 export interface IDashboardStats {
@@ -34,6 +33,19 @@ export interface ITopVendorSpend {
   spent: number;
 }
 
+export type VendorSortMode = 'spend' | 'name';
+
+export interface IVendorCardItem {
+  vendorName: string;
+  displayName: string;
+  logoUrl: string;
+  spent: number;
+  isWatched: boolean;
+  hasSpend: boolean;
+  sourceIndex: number;
+  usesFallbackIcon: boolean;
+}
+
 export interface IWatchedCategoryResolved {
   category: ICategory;
   spent: number;
@@ -45,18 +57,6 @@ export interface IWatchedCategoryMissing {
   displayName: string;
 }
 
-export interface IWatchedVendorResolved {
-  key: string;
-  displayName: string;
-  logoUrl: string;
-  spent: number;
-}
-
-export interface IWatchedVendorMissing {
-  key: string;
-  displayName: string;
-}
-
 export interface IDashboardViewModel {
   stats: IDashboardStats;
   overBudgetCategories: IOverBudgetCategory[];
@@ -64,9 +64,7 @@ export interface IDashboardViewModel {
   watchedCategoriesResolved: IWatchedCategoryResolved[];
   watchedCategoriesMissing: IWatchedCategoryMissing[];
   vendorMappings: IVendorLogoRule[];
-  topSpendingVendors: ITopVendorSpend[];
-  watchedVendorsResolved: IWatchedVendorResolved[];
-  watchedVendorsMissing: IWatchedVendorMissing[];
+  vendorCards: IVendorCardItem[];
 }
 
 function roundMoney(value: number): number {
@@ -167,11 +165,18 @@ export function buildDashboardViewModel(
     .sort((a, b) => b.spent - a.spent)
     .slice(0, 5);
 
-  const topSpendingVendors = Array.from(spentByVendor.values())
+  const vendorSpendItems = Array.from(spentByVendor.values())
     .filter((row): row is ITopVendorSpend => !!row)
     .filter(row => row.spent > 0)
-    .sort((a, b) => b.spent - a.spent)
-    .slice(0, 5);
+    .sort((a, b) => b.spent - a.spent);
+
+  const mappingIndexByVendorKey = new Map<string, number>();
+  vendorMappings.forEach((mapping, index) => {
+    const key = normalizeVendorKey(mapping?.vendorName || '');
+    if (key.length > 0 && !mappingIndexByVendorKey.has(key)) {
+      mappingIndexByVendorKey.set(key, index);
+    }
+  });
 
   const categoryByNormalizedName = new Map<string, ICategory>();
   categories.forEach(c => {
@@ -183,8 +188,6 @@ export function buildDashboardViewModel(
 
   const watchedCategoriesResolved: IWatchedCategoryResolved[] = [];
   const watchedCategoriesMissing: IWatchedCategoryMissing[] = [];
-  const watchedVendorsResolved: IWatchedVendorResolved[] = [];
-  const watchedVendorsMissing: IWatchedVendorMissing[] = [];
   normalizedWatchKeys.forEach(key => {
     const category = categoryByNormalizedName.get(key);
     if (category) {
@@ -202,21 +205,43 @@ export function buildDashboardViewModel(
     }
   });
 
+  const vendorCardByKey = new Map<string, IVendorCardItem>();
+  vendorSpendItems.forEach(item => {
+    const key = normalizeVendorKey(item.vendorName);
+    vendorCardByKey.set(key, {
+      vendorName: item.vendorName,
+      displayName: item.vendorName,
+      logoUrl: item.logoUrl,
+      spent: roundMoney(item.spent),
+      isWatched: normalizedWatchedVendorKeys.includes(key),
+      hasSpend: true,
+      sourceIndex: mappingIndexByVendorKey.get(key) ?? -1,
+      usesFallbackIcon: !item.logoUrl
+    });
+  });
+
   normalizedWatchedVendorKeys.forEach(key => {
-    const vendorEntry = spentByVendor.get(key);
-    if (vendorEntry) {
-      watchedVendorsResolved.push({
-        key,
-        displayName: vendorEntry.vendorName,
-        logoUrl: vendorEntry.logoUrl,
-        spent: roundMoney(vendorEntry.spent)
-      });
-    } else {
-      watchedVendorsMissing.push({
-        key,
-        displayName: key.replace(/\b\w/g, char => char.toUpperCase())
-      });
+    if (vendorCardByKey.has(key)) {
+      const existing = vendorCardByKey.get(key);
+      if (existing) {
+        existing.isWatched = true;
+      }
+      return;
     }
+    const sourceIndex = mappingIndexByVendorKey.get(key) ?? -1;
+    const mapping = sourceIndex >= 0 ? vendorMappings[sourceIndex] : undefined;
+    const displayName = (mapping?.vendorName || '').trim() || key.replace(/\b\w/g, char => char.toUpperCase());
+    const logoUrl = (mapping?.logoUrl || '').trim();
+    vendorCardByKey.set(key, {
+      vendorName: displayName,
+      displayName,
+      logoUrl,
+      spent: 0,
+      isWatched: true,
+      hasSpend: false,
+      sourceIndex,
+      usesFallbackIcon: !logoUrl
+    });
   });
 
   const actualIncome = roundMoney(
@@ -240,9 +265,7 @@ export function buildDashboardViewModel(
     watchedCategoriesResolved,
     watchedCategoriesMissing,
     vendorMappings: vendorMappings.slice(),
-    topSpendingVendors,
-    watchedVendorsResolved,
-    watchedVendorsMissing
+    vendorCards: Array.from(vendorCardByKey.values())
   };
 }
 
@@ -255,13 +278,12 @@ export function buildDashboardViewModel(
 })
 export class DashboardComponent implements OnInit, OnDestroy {
   private dataSub: Subscription;
-  private vendorMappingLimit = 8;
 
   viewModel: IDashboardViewModel = buildDashboardViewModel([], [], '', []);
   balances: Array<{ key: string; value: any }> = [];
   availableWatchOptions: ICategory[] = [];
-  watchedVendorWatchOptions: string[] = [];
-  vendorMappingFilter = '';
+  vendorSearch = '';
+  vendorSortMode: VendorSortMode = 'spend';
 
   constructor(
     public service: DbService,
@@ -285,7 +307,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
         this.availableWatchOptions = cats
           .filter(c => (c.name || '').trim().length > 0 && (c.name || '').toUpperCase() !== 'INCOME')
           .sort((a, b) => a.name.localeCompare(b.name));
-        this.watchedVendorWatchOptions = this.getWatchedVendorOptions(vendorMappings || []);
         this.viewModel = buildDashboardViewModel(
           cats,
           trans,
@@ -298,14 +319,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
       });
     });
     this.loadBalances();
-  }
-
-  getWatchedVendorOptions(vendorMappings: IVendorLogoRule[]): string[] {
-    const mappedVendors = (vendorMappings || [])
-      .map(mapping => (mapping?.vendorName || '').trim())
-      .filter(v => v.length > 0);
-    return Array.from(new Set(mappedVendors))
-      .sort((a, b) => a.localeCompare(b));
   }
 
   ngOnDestroy() {
@@ -346,24 +359,8 @@ export class DashboardComponent implements OnInit, OnDestroy {
     return item.key;
   }
 
-  trackByVendorMapping(index: number, item: IVendorLogoRule) {
-    return `${item.pattern}:${item.vendorName}`;
-  }
-
-  trackByVendorMappingDisplayItem(index: number, item: { mapping: IVendorLogoRule; sourceIndex: number }) {
-    return item.sourceIndex >= 0 ? item.sourceIndex : `${index}:${item.mapping?.vendorName || ''}:${item.mapping?.pattern || ''}`;
-  }
-
-  trackByTopVendor(index: number, item: ITopVendorSpend) {
-    return item.vendorName;
-  }
-
-  trackByWatchedVendorResolved(index: number, item: IWatchedVendorResolved) {
-    return item.key;
-  }
-
-  trackByWatchedVendorMissing(index: number, item: IWatchedVendorMissing) {
-    return item.key;
+  trackByVendorGridItem(index: number, item: IVendorCardItem) {
+    return `${normalizeVendorKey(item.vendorName)}:${item.sourceIndex >= 0 ? item.sourceIndex : index}`;
   }
 
   getTransactionQueryParamsForCategory(categoryName: string) {
@@ -399,68 +396,90 @@ export class DashboardComponent implements OnInit, OnDestroy {
     });
   }
 
-  openAddWatchedVendorModal() {
-    const watchedVendorKeys = this.service.dashboardPreferences.getValue()?.watchedVendorKeys || [];
-    const vendorOptions = this.watchedVendorWatchOptions.filter(v => !watchedVendorKeys.includes(normalizeVendorKey(v)));
-    const dialogRef = this.dialog.open(DashboardWatchVendorModalComponent, {
-      width: '450px',
-      maxWidth: '90vw',
-      autoFocus: false,
-      data: { vendorOptions }
-    });
-    dialogRef.afterClosed().subscribe((vendorName: string | undefined) => {
-      if (!vendorName) { return; }
-      this.addWatchedVendor(vendorName);
-    });
-  }
-
   openAddVendorMappingModal() {
     const dialogRef = this.dialog.open(DashboardVendorMappingModalComponent, {
       width: '520px',
       maxWidth: '90vw',
       autoFocus: false,
-      data: {}
+      data: { watched: false }
     });
     dialogRef.afterClosed().subscribe((result: DashboardVendorMappingModalResult | undefined) => {
       if (!result || result.action !== 'save') { return; }
-      this.addVendorMapping(result.mapping);
+      this.addVendor(result.mapping, result.watched);
     });
   }
 
   openEditVendorMappingModal(mapping: IVendorLogoRule, index: number) {
+    const watchedVendorKeys = this.service.dashboardPreferences.getValue()?.watchedVendorKeys || [];
     const dialogRef = this.dialog.open(DashboardVendorMappingModalComponent, {
       width: '520px',
       maxWidth: '90vw',
       autoFocus: false,
-      data: { mapping, index }
+      data: {
+        mapping,
+        index,
+        watched: watchedVendorKeys.includes(normalizeVendorKey(mapping?.vendorName || ''))
+      }
     });
     dialogRef.afterClosed().subscribe((result: DashboardVendorMappingModalResult | undefined) => {
       if (!result) { return; }
       if (result.action === 'save') {
-        this.updateVendorMapping(result.mapping, index);
+        this.updateVendor(result.mapping, index, result.watched, mapping?.vendorName || '');
       } else if (result.action === 'delete') {
-        this.removeVendorMapping(index);
+        this.removeVendorMapping(index, mapping?.vendorName || '');
       }
     });
   }
 
-  getVendorMappingDisplayItems(): Array<{ mapping: IVendorLogoRule; sourceIndex: number }> {
-    const filter = (this.vendorMappingFilter || '').trim().toLowerCase();
-    const mappings = (this.viewModel?.vendorMappings || [])
-      .filter(mapping => {
-        if (!filter) { return true; }
-        return (mapping?.vendorName || '').toLowerCase().includes(filter);
-      });
-
-    const visible = filter ? mappings : mappings.slice(0, this.vendorMappingLimit);
-    return visible.map(mapping => ({
-      mapping,
-      sourceIndex: (this.viewModel?.vendorMappings || []).findIndex(v => v === mapping)
-    }));
+  openVendorCardEdit(item: IVendorCardItem) {
+    if (item.sourceIndex >= 0) {
+      this.openEditVendorMappingModal(this.viewModel.vendorMappings[item.sourceIndex], item.sourceIndex);
+      return;
+    }
+    const dialogRef = this.dialog.open(DashboardVendorMappingModalComponent, {
+      width: '520px',
+      maxWidth: '90vw',
+      autoFocus: false,
+      data: {
+        initialVendorName: item.displayName,
+        watched: item.isWatched
+      }
+    });
+    dialogRef.afterClosed().subscribe((result: DashboardVendorMappingModalResult | undefined) => {
+      if (!result || result.action !== 'save') { return; }
+      this.addVendor(result.mapping, result.watched);
+    });
   }
 
-  onVendorMappingFilterChange(value: string) {
-    this.vendorMappingFilter = value || '';
+  getVendorGridItems(): IVendorCardItem[] {
+    const search = (this.vendorSearch || '').trim().toLowerCase();
+    const sortByMode = (a: IVendorCardItem, b: IVendorCardItem) => {
+      if (this.vendorSortMode === 'name') {
+        return a.displayName.localeCompare(b.displayName);
+      }
+      return b.spent - a.spent || a.displayName.localeCompare(b.displayName);
+    };
+    const items = (this.viewModel?.vendorCards || [])
+      .filter(item => {
+        if (!search) { return true; }
+        return (item?.displayName || '').toLowerCase().includes(search);
+      })
+      .sort((a, b) => {
+        if (a.isWatched !== b.isWatched) {
+          return a.isWatched ? -1 : 1;
+        }
+        return sortByMode(a, b);
+      });
+
+    return items;
+  }
+
+  onVendorSearchChange(value: string) {
+    this.vendorSearch = value || '';
+  }
+
+  setVendorSortMode(mode: VendorSortMode) {
+    this.vendorSortMode = mode;
   }
 
   async addWatchedCategory(categoryName: string) {
@@ -471,36 +490,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
     await this.persistWatchedPreferences({
       watchedCategoryKeys: [...current, key],
       watchedVendorKeys: this.service.dashboardPreferences.getValue()?.watchedVendorKeys || []
-    });
-  }
-
-  async addWatchedVendor(vendorName: string) {
-    const key = normalizeVendorKey(vendorName);
-    if (!key) { return; }
-    const preferences = this.service.dashboardPreferences.getValue();
-    const current = preferences?.watchedVendorKeys || [];
-    if (current.includes(key)) { return; }
-    await this.persistWatchedPreferences({
-      watchedCategoryKeys: preferences?.watchedCategoryKeys || [],
-      watchedVendorKeys: [...current, key]
-    });
-  }
-
-  async removeWatchedVendorByName(vendorName: string) {
-    const key = normalizeVendorKey(vendorName);
-    if (!key) { return; }
-    const current = this.service.dashboardPreferences.getValue()?.watchedVendorKeys || [];
-    await this.persistWatchedPreferences({
-      watchedCategoryKeys: this.service.dashboardPreferences.getValue()?.watchedCategoryKeys || [],
-      watchedVendorKeys: current.filter(k => k !== key)
-    });
-  }
-
-  async removeWatchedVendorMissing(key: string) {
-    const current = this.service.dashboardPreferences.getValue()?.watchedVendorKeys || [];
-    await this.persistWatchedPreferences({
-      watchedCategoryKeys: this.service.dashboardPreferences.getValue()?.watchedCategoryKeys || [],
-      watchedVendorKeys: current.filter(k => k !== key)
     });
   }
 
@@ -522,12 +511,18 @@ export class DashboardComponent implements OnInit, OnDestroy {
     });
   }
 
-  async removeVendorMapping(index: number) {
+  async removeVendorMapping(index: number, vendorName?: string) {
     const mappings = this.service.vendorMappings.getValue() || [];
     if (index < 0 || index >= mappings.length) { return; }
     const updated = [...mappings];
     updated.splice(index, 1);
     await this.persistVendorMappings(updated);
+    await this.setVendorWatchedState(vendorName || '', false);
+  }
+
+  private async addVendor(mapping: IVendorLogoRule, watched: boolean) {
+    await this.addVendorMapping(mapping);
+    await this.setVendorWatchedState(mapping?.vendorName || '', watched);
   }
 
   private async addVendorMapping(mapping: IVendorLogoRule) {
@@ -542,6 +537,16 @@ export class DashboardComponent implements OnInit, OnDestroy {
     const deduped = current.filter(rule => `${normalizeVendorKey(rule.pattern)}-${normalizeVendorKey(rule.vendorName)}` !== ruleKey);
     const updated = [trimmed, ...deduped];
     await this.persistVendorMappings(updated);
+  }
+
+  private async updateVendor(mapping: IVendorLogoRule, index: number, watched: boolean, previousVendorName: string) {
+    await this.updateVendorMapping(mapping, index);
+    const previousKey = normalizeVendorKey(previousVendorName);
+    const currentKey = normalizeVendorKey(mapping?.vendorName || '');
+    if (previousKey && previousKey !== currentKey) {
+      await this.setVendorWatchedState(previousVendorName, false);
+    }
+    await this.setVendorWatchedState(mapping?.vendorName || '', watched);
   }
 
   private async updateVendorMapping(mapping: IVendorLogoRule, index: number) {
@@ -564,6 +569,20 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   private async persistVendorMappings(vendorMappings: IVendorLogoRule[]) {
     await this.service.saveVendorMappings(vendorMappings);
+  }
+
+  private async setVendorWatchedState(vendorName: string, watched: boolean) {
+    const key = normalizeVendorKey(vendorName);
+    if (!key) { return; }
+    const preferences = this.service.dashboardPreferences.getValue();
+    const currentWatched = preferences?.watchedVendorKeys || [];
+    const nextWatched = watched
+      ? Array.from(new Set([...currentWatched, key]))
+      : currentWatched.filter(k => k !== key);
+    await this.persistWatchedPreferences({
+      watchedCategoryKeys: preferences?.watchedCategoryKeys || [],
+      watchedVendorKeys: nextWatched
+    });
   }
 
   private async persistWatchedPreferences(update: { watchedCategoryKeys?: string[]; watchedVendorKeys?: string[] }) {

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -27,6 +27,7 @@ import { MatTableModule } from '@angular/material/table';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MomentDateModule } from '@angular/material-moment-adapter';
 import { PickerModule } from '@ctrl/ngx-emoji-mart';
 
@@ -63,6 +64,7 @@ import { PickerModule } from '@ctrl/ngx-emoji-mart';
     MatProgressBarModule,
     MatProgressSpinnerModule,
     MatButtonToggleModule,
+    MatSlideToggleModule,
     PickerModule
   ],
   exports: [
@@ -97,6 +99,7 @@ import { PickerModule } from '@ctrl/ngx-emoji-mart';
     MatProgressBarModule,
     MatProgressSpinnerModule,
     MatButtonToggleModule,
+    MatSlideToggleModule,
     PickerModule
   ]
 })


### PR DESCRIPTION
This pull request significantly redesigns the vendor management experience on the dashboard. It unifies the previously separate "watched vendors," "top spending vendors," and "vendor mappings" sections into a single, searchable, sortable grid of vendor cards. The modal for adding/editing vendors now supports a "watched" toggle, and the UI and styles have been updated for clarity and consistency. The tests and data model have been refactored to support these changes.

**Dashboard Vendor Experience Redesign:**

- Replaces the separate lists for watched vendors, top spending vendors, and mappings with a unified vendor card grid. The grid supports searching, sorting (by spend or name), and visually distinguishes watched vendors. The card actions menu allows editing mappings and viewing transactions. [[1]](diffhunk://#diff-4e1d85317f677d9c4c9f0409ff020e0271e3901323ebc6b8c1d40fdf7ab3c33aL198-R267) [[2]](diffhunk://#diff-10e695123f30655f8f9aeae0edd70c29812dbe66e497011406118cdb86348e12R100-R106) [[3]](diffhunk://#diff-10e695123f30655f8f9aeae0edd70c29812dbe66e497011406118cdb86348e12L136-R165) [[4]](diffhunk://#diff-10e695123f30655f8f9aeae0edd70c29812dbe66e497011406118cdb86348e12L158-R236) [[5]](diffhunk://#diff-10e695123f30655f8f9aeae0edd70c29812dbe66e497011406118cdb86348e12R279-R284)

- Updates the vendor add/edit modal to include a "Watch this vendor" toggle, and adjusts the modal title for clarity. The modal now passes the watched state in its result, and can be pre-populated with an initial vendor name or watched state. [[1]](diffhunk://#diff-8f70587628a2d7e188fcfcecfb6a3bf8708c16ce6d066fdc30ea6f0225e92535L18-R18) [[2]](diffhunk://#diff-8f70587628a2d7e188fcfcecfb6a3bf8708c16ce6d066fdc30ea6f0225e92535R50-R51) [[3]](diffhunk://#diff-7bdf8c5db82b92fffcd2050c4c16304d35b43074c389686f44e41a895da4a8c1L11-R19) [[4]](diffhunk://#diff-7bdf8c5db82b92fffcd2050c4c16304d35b43074c389686f44e41a895da4a8c1R34) [[5]](diffhunk://#diff-7bdf8c5db82b92fffcd2050c4c16304d35b43074c389686f44e41a895da4a8c1R47-R50) [[6]](diffhunk://#diff-7bdf8c5db82b92fffcd2050c4c16304d35b43074c389686f44e41a895da4a8c1L92-R99) [[7]](diffhunk://#diff-7bdf8c5db82b92fffcd2050c4c16304d35b43074c389686f44e41a895da4a8c1L121-R128)

**Styling and Layout Improvements:**

- Refines dashboard and modal styles for better usability and appearance, including grid responsiveness, card layout, icon usage, and spacing adjustments. [[1]](diffhunk://#diff-88add19f935cb7016a23c38459f148d4b4cfe90bd88ac6e5d52710911f7b6717L20-R20) [[2]](diffhunk://#diff-10e695123f30655f8f9aeae0edd70c29812dbe66e497011406118cdb86348e12R100-R106) [[3]](diffhunk://#diff-10e695123f30655f8f9aeae0edd70c29812dbe66e497011406118cdb86348e12L136-R165) [[4]](diffhunk://#diff-10e695123f30655f8f9aeae0edd70c29812dbe66e497011406118cdb86348e12L158-R236) [[5]](diffhunk://#diff-10e695123f30655f8f9aeae0edd70c29812dbe66e497011406118cdb86348e12R279-R284)

**Testing and Data Model Updates:**

- Refactors and expands tests to validate the new vendor card model, ensuring watched vendors without spend or mappings are still shown, and that the new grid logic works as intended. [[1]](diffhunk://#diff-a8f1c8f0c3d0ef3480732f61cb38c806dc6ff9fe84a80b7999afddce66dfda74L53-R53) [[2]](diffhunk://#diff-a8f1c8f0c3d0ef3480732f61cb38c806dc6ff9fe84a80b7999afddce66dfda74L79-R101)

These changes result in a more streamlined, flexible, and user-friendly vendor management interface on the dashboard.